### PR TITLE
Add optional `extra_tags` kwarg to `bandcamp.candidates`

### DIFF
--- a/beetsplug/bandcamp.py
+++ b/beetsplug/bandcamp.py
@@ -73,7 +73,7 @@ class BandcampPlugin(plugins.BeetsPlugin):
             dist.add('source', self.config['source_weight'].as_number())
         return dist
 
-    def candidates(self, items, artist, album, va_likely):
+    def candidates(self, items, artist, album, va_likely, extra_tags=None):
         """Returns a list of AlbumInfo objects for bandcamp search results
         matching an album and artist (if not various).
         """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='beets-bandcamp',
-    version='0.1.3',
+    version='0.1.4',
     description='Plugin for beets (http://beets.io) to use bandcamp as an autotagger source.',
     long_description=open('README.rst').read(),
     author='Ariel George',


### PR DESCRIPTION
Update `bandcamp.candidates` function to reflect recently added `extra_tags` keyword argument, to avoid a [`TypeError`](https://github.com/beetbox/beets/issues/3540).

Similar PR: https://github.com/beetbox/beets/pull/3531